### PR TITLE
Upload files directly to discord to embed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM golang:1.19-alpine AS build
 
-COPY . /app
-
 WORKDIR /app
 
+COPY ./go.mod ./go.mod
+COPY ./go.sum ./go.sum
+
 RUN go mod download
+
+COPY . /app
 
 RUN go build -o /service-bin
 

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"strings"
-	"time"
-
 	"github.com/avast/retry-go/v4"
 	"github.com/bwmarrin/discordgo"
 	"github.com/pkg/errors"
@@ -15,8 +11,10 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.uber.org/zap"
-
+	"io"
 	"openai-discord-bot/bot/storage"
+	"os"
+	"strings"
 )
 
 type AIBot struct {
@@ -106,6 +104,7 @@ func (b *AIBot) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) 
 		span.RecordError(err)
 		return
 	}
+	b.logger.Info("loaded thread context", zap.Int("thread_length", len(threadPromptContext)))
 
 	// Strip our UserId out of messages to keep the record from being too confusing,
 	sanitizedUserPrompt := strings.ReplaceAll(m.Content, fmt.Sprintf("<@%s>", s.State.User.ID), "")
@@ -113,7 +112,7 @@ func (b *AIBot) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) 
 	// Let users know we're "typing", the call to OpenAI can take a few seconds
 	_ = s.ChannelTyping(responseChannel)
 
-	if strings.Contains(strings.ToLower(sanitizedUserPrompt), "draw me a picture of") {
+	if strings.Contains(strings.ToLower(sanitizedUserPrompt), "🎨") || strings.Contains(strings.ToLower(sanitizedUserPrompt), "draw me a picture of") {
 		// Strip the prompt prefix out of the message
 		sanitizedUserPrompt = strings.ReplaceAll(strings.ToLower(m.Content), "draw me a picture of", "")
 		err = b.handleImageMessage(ctx, responseChannel, sanitizedUserPrompt, m)
@@ -169,35 +168,63 @@ func (b *AIBot) handleImageMessage(ctx context.Context, responseChannel string, 
 		return fmt.Errorf("failed to get image from openai: %w", err)
 	}
 
-	// Retrieve the image from openai and store it ourselves on S3
-	imageKey, err := b.imageStorage.StoreImageFromURL(ctx, m.GuildID, responseImage.Data[0].URL)
+	// Retrieve the image from openai
+	imageReader, imageLength, err := b.imageStorage.GetImageFromURL(ctx, responseImage.Data[0].URL)
 	if err != nil {
 		return fmt.Errorf("failed to store retrieved image: %w", err)
 	}
-	imageUrl := fmt.Sprintf("https://sillybullshit.click/%s", imageKey)
+	b.logger.Info("image retrieval", zap.Int64("image_length", imageLength), zap.String("url", responseImage.Data[0].URL))
 
-	// Record the image response to the thread context
-	err = b.storage.AddThreadMessage(ctx, responseChannel, "Bot", responseImage.Data[0].URL)
-	if err != nil {
-		return fmt.Errorf("failed to record response to thread context: %w", err)
-	}
+	defer func() {
+		closeErr := imageReader.Close()
+		if closeErr != nil {
+			b.logger.Error("failed to close image request body", zap.Error(closeErr))
+		}
+	}()
 
-	// Embed the image in a discord response, and send it
-	_, err = b.discordSession.ChannelMessageSendEmbed(responseChannel, &discordgo.MessageEmbed{
-		URL:         imageUrl,
-		Type:        discordgo.EmbedTypeImage,
-		Title:       "a picture I drawed",
-		Description: m.Content,
-		Timestamp:   time.Now().Format(time.RFC3339),
-		Image: &discordgo.MessageEmbedImage{
-			URL:    imageUrl,
-			Width:  512,
-			Height: 512,
+	// Tee the image reading stream, so that we can upload it to discord and S3 at the same time
+	pipeReader, pipeWriter := io.Pipe()
+	imageTeeReader := io.TeeReader(imageReader, pipeWriter)
+
+	// Record the image to S3
+	go func() {
+		defer func() {
+			pipeErr := pipeWriter.Close()
+			if pipeErr != nil {
+				b.logger.Error("failed to close the pipeWriter", zap.Error(pipeErr))
+			}
+		}()
+
+		imageKey, err := b.imageStorage.StoreImage(ctx, m.GuildID, imageTeeReader, imageLength)
+		if err != nil {
+			b.logger.Error("failed to store a copy of the image in S3", zap.Error(err))
+			return
+		}
+
+		imageUrl := fmt.Sprintf("https://sillybullshit.click/%s", imageKey)
+
+		// Record the image response to the thread context
+		err = b.storage.AddThreadMessage(ctx, responseChannel, "Bot", imageUrl)
+		if err != nil {
+			b.logger.Error("failed to store a copy of the image in S3", zap.Error(err))
+		}
+	}()
+
+	// Embed the image in a discord message, and send it
+	_, err = b.discordSession.ChannelMessageSendComplex(responseChannel, &discordgo.MessageSend{
+		Content:   "a picture I drawed",
+		Reference: m.Reference(),
+		File: &discordgo.File{
+			Name:        "danbot-drawing.png",
+			ContentType: "image/png",
+			Reader:      pipeReader,
 		},
 	}, discordgo.WithContext(ctx))
+
 	if err != nil {
 		return fmt.Errorf("failed to send embedded image to discord: %w", err)
 	}
+	b.logger.Info("sent image response")
 
 	return nil
 }

--- a/bot/storage/imagesS3.go
+++ b/bot/storage/imagesS3.go
@@ -50,7 +50,7 @@ func (i *ImageStorage) GetImageFromURL(ctx context.Context, URL string) (io.Read
 	return resp.Body, resp.ContentLength, nil
 }
 
-func (i *ImageStorage) StoreImage(ctx context.Context, groupId string, reader io.Reader, len int64) (string, error) {
+func (i *ImageStorage) StoreImage(ctx context.Context, groupId string, reader io.Reader, contentLength int64) (string, error) {
 	uid, err := ksuid.NewRandomWithTime(time.Now())
 	if err != nil {
 		return "", fmt.Errorf("somehow failed to generate a uid: %w", err)
@@ -64,7 +64,7 @@ func (i *ImageStorage) StoreImage(ctx context.Context, groupId string, reader io
 		Bucket:        aws.String(i.bucketName),
 		Key:           constructedKey,
 		Body:          reader,
-		ContentLength: len,
+		ContentLength: contentLength,
 		ContentType:   aws.String("image/png"),
 	})
 

--- a/bot/storage/imagesS3.go
+++ b/bot/storage/imagesS3.go
@@ -32,32 +32,25 @@ func NewImageStorage(config aws.Config, logger *zap.Logger, bucketName string) *
 	}
 }
 
-func (i *ImageStorage) StoreImageFromURL(ctx context.Context, groupId string, URL string) (string, error) {
+func (i *ImageStorage) GetImageFromURL(ctx context.Context, URL string) (io.ReadCloser, int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, URL, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create image request: %w", err)
+		return nil, 0, fmt.Errorf("failed to create image request: %w", err)
 	}
 
 	resp, err := i.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to request image from URL: %w", err)
+		return nil, 0, fmt.Errorf("failed to request image from URL: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected response status: %d", resp.StatusCode)
+		return nil, 0, fmt.Errorf("unexpected response status: %d", resp.StatusCode)
 	}
 
-	defer func() {
-		err = resp.Body.Close()
-		if err != nil {
-			i.logger.Warn("failed to close image response body", zap.Error(err))
-		}
-	}()
-
-	return i.StoreImage(ctx, groupId, resp.Body, resp.ContentLength)
+	return resp.Body, resp.ContentLength, nil
 }
 
-func (i *ImageStorage) StoreImage(ctx context.Context, groupId string, reader io.Reader, contentLength int64) (string, error) {
+func (i *ImageStorage) StoreImage(ctx context.Context, groupId string, reader io.Reader, len int64) (string, error) {
 	uid, err := ksuid.NewRandomWithTime(time.Now())
 	if err != nil {
 		return "", fmt.Errorf("somehow failed to generate a uid: %w", err)
@@ -70,8 +63,8 @@ func (i *ImageStorage) StoreImage(ctx context.Context, groupId string, reader io
 	_, err = i.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(i.bucketName),
 		Key:           constructedKey,
-		ContentLength: contentLength,
 		Body:          reader,
+		ContentLength: len,
 		ContentType:   aws.String("image/png"),
 	})
 


### PR DESCRIPTION
Upload files directly to discord when embedding them, to make them easier to share (trusted domain)

However I still want to preserve the images in our thread context, so also continue to upload them to S3 with valid constructed links in the thread context

This also adds 🎨 as a simpler command to request a drawing than the full "draw me a picture of" prompt