### PR TITLE
GPT3Ada is deprecated, move to GPT3Turbo

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -114,7 +114,7 @@ func GetOpenAISession() (*gpt.Client, error) {
 	client := gpt.NewClientWithConfig(openaiCfg)
 
 	request := gpt.CompletionRequest{
-		Model:     gpt.GPT3Ada,
+		Model:     gpt.GPT3Dot5Turbo,
 		Prompt:    "are you alive?",
 		Suffix:    "",
 		MaxTokens: 5,


### PR DESCRIPTION
Startup failures, whoops!

![image](https://github.com/grevian/openai-discord-bot/assets/603334/cb0c87ed-a9bd-46f9-8594-534b08bcb79b)
