### PR TITLE
Remove reviewers from dependabot.yml and add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grevian

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,6 @@ updates:
         update-types: ["version-update:semver-patch"]
     labels:
       - "dependencies"
-    reviewers:
-      - "grevian"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Based on notifications like the below

<img width="1415" height="256" alt="image" src="https://github.com/user-attachments/assets/72428740-58fb-45ad-91b9-b5fee7d7902a" />
