### PR TITLE
Add packages:write permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository


### PR DESCRIPTION
We don't strictly need to publish the image to validate that it builds, but it makes the existing actions more convenient, and since the aws-copilot CLI tools are now deprecated it's probably a good step towards moving to a new deployment mechanism 😭 