### PR TITLE
Harden deploys and stop OpenAI-quota crash loops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ RUN go build -o /service-bin
 
 FROM alpine
 
-ENV BOT_OPENAI_AUTH_TOKEN=""
-ENV BOT_DISCORD_TOKEN=""
+# Required at runtime (NOT baked into the image):
+#   BOT_DISCORD_TOKEN     - injected in ECS via terraform/ssm.tf -> aws_ssm_parameter.discord_token
+#   BOT_OPENAI_AUTH_TOKEN - injected in ECS via terraform/ssm.tf -> aws_ssm_parameter.openai_token
+# Locally, set these in your shell or a .env file consumed by your runner.
 
 WORKDIR /app
 COPY --from=build /service-bin .

--- a/adot/otel-agent-config.yaml
+++ b/adot/otel-agent-config.yaml
@@ -21,7 +21,12 @@ exporters:
     endpoint: api.honeycomb.io:443
     headers:
       x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
+      x-honeycomb-dataset: "ecs_metrics"
   otlp/metrics:
+    endpoint: api.honeycomb.io:443
+    headers:
+      x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
+  otlp/logs:
     endpoint: api.honeycomb.io:443
     headers:
       x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
@@ -40,4 +45,7 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [otlp/metrics]
-
+    logs:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ otlp/logs ]

--- a/adot/otel-agent-config.yaml
+++ b/adot/otel-agent-config.yaml
@@ -16,15 +16,15 @@ exporters:
   otlp/traces:
     endpoint: api.honeycomb.io:443
     headers:
-      x-honeycomb-team: SET_HONEYCOMB_API_KEY_HERE
+      x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
   otlp/containermetrics:
     endpoint: api.honeycomb.io:443
     headers:
-      x-honeycomb-team: SET_HONEYCOMB_API_KEY_HERE
+      x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
   otlp/metrics:
     endpoint: api.honeycomb.io:443
     headers:
-      x-honeycomb-team: SET_HONEYCOMB_API_KEY_HERE
+      x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
 
 service:
   pipelines:

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -3,16 +3,17 @@ package bot
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 	gpt "github.com/sashabaranov/go-openai"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -24,6 +25,7 @@ import (
 type AIBot struct {
 	openapiClient  *gpt.Client
 	botCtx         context.Context
+	shutdown       context.CancelFunc
 	discordSession *discordgo.Session
 	basePrompt     []gpt.ChatCompletionMessage
 	storage        *storage.Storage
@@ -35,7 +37,25 @@ func (b *AIBot) Go() error {
 	return nil
 }
 
-func NewAIBot(botCtx context.Context, aiClient *gpt.Client, discordSession *discordgo.Session, storage *storage.Storage, imageStorage *storage.ImageStorage) *AIBot {
+// isFatalOpenAIError reports whether err indicates a condition that won't
+// recover on retry: an exhausted quota or a revoked / invalid API key. When
+// true the caller should stop calling OpenAI and trigger process shutdown so
+// that ECS does not pile up a crash-loop of half-open Discord sessions.
+func isFatalOpenAIError(err error) bool {
+	var apiErr *gpt.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.HTTPStatusCode == http.StatusUnauthorized {
+		return true
+	}
+	if code, ok := apiErr.Code.(string); ok {
+		return code == "insufficient_quota" || code == "invalid_api_key"
+	}
+	return false
+}
+
+func NewAIBot(botCtx context.Context, shutdown context.CancelFunc, aiClient *gpt.Client, discordSession *discordgo.Session, storage *storage.Storage, imageStorage *storage.ImageStorage) *AIBot {
 	promptBytes, err := os.ReadFile("prompts/danbo.json")
 	if err != nil {
 		log.Panic("Failed to read initial prompt", err)
@@ -54,6 +74,7 @@ func NewAIBot(botCtx context.Context, aiClient *gpt.Client, discordSession *disc
 		discordSession: discordSession,
 		openapiClient:  aiClient,
 		botCtx:         botCtx,
+		shutdown:       shutdown,
 		basePrompt:     promptMessages.Prompt,
 		storage:        storage,
 		imageStorage:   imageStorage,
@@ -178,6 +199,9 @@ func (b *AIBot) handleImageMessage(ctx context.Context, responseChannel string, 
 	)
 	responseImage, err := b.openapiClient.CreateImage(ctx, imageRequest)
 	if err != nil {
+		if isFatalOpenAIError(err) {
+			b.handleFatalOpenAIError(ctx, err)
+		}
 		return fmt.Errorf("failed to get image from openai: %w", err)
 	}
 
@@ -270,6 +294,10 @@ func (b *AIBot) handleCompletionPrompt(ctx context.Context, responseChannel stri
 		func() error {
 			response, err := b.openapiClient.CreateChatCompletion(ctx, request)
 			if err != nil {
+				if isFatalOpenAIError(err) {
+					b.handleFatalOpenAIError(ctx, err)
+					return retry.Unrecoverable(err)
+				}
 				logger.ErrorContext(ctx, "Failed to retrieve completion from OpenAI", slog.Any("error", err))
 				return err
 			}
@@ -353,6 +381,29 @@ func (b *AIBot) handleThreading(ctx context.Context, s *discordgo.Session, m *di
 		}
 	}
 	return
+}
+
+// handleFatalOpenAIError logs the terminal OpenAI failure with enough detail
+// to identify the cause in CloudWatch (quota vs revoked key), then triggers a
+// graceful process shutdown so main.go can close the Discord session cleanly.
+// Repeated calls are safe — context.CancelFunc is idempotent.
+func (b *AIBot) handleFatalOpenAIError(ctx context.Context, err error) {
+	logger := slog.Default().WithGroup("openai")
+	var apiErr *gpt.APIError
+	attrs := []any{slog.Any("error", err)}
+	if errors.As(err, &apiErr) {
+		attrs = append(attrs,
+			slog.Int("http_status", apiErr.HTTPStatusCode),
+			slog.String("openai_message", apiErr.Message),
+		)
+		if code, ok := apiErr.Code.(string); ok {
+			attrs = append(attrs, slog.String("openai_error_code", code))
+		}
+	}
+	logger.ErrorContext(ctx, "Unrecoverable OpenAI error; triggering shutdown", attrs...)
+	if b.shutdown != nil {
+		b.shutdown()
+	}
 }
 
 func (b *AIBot) Shutdown() {

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -115,19 +114,6 @@ func GetOpenAISession() (*gpt.Client, error) {
 		Transport: otelhttp.NewTransport(http.DefaultTransport),
 	}
 	client := gpt.NewClientWithConfig(openaiCfg)
-
-	request := gpt.CompletionRequest{
-		Model:     gpt.GPT3Dot5TurboInstruct,
-		Prompt:    "are you alive?",
-		Suffix:    "",
-		MaxTokens: 5,
-	}
-	requestCtx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	defer cancel()
-	_, err := client.CreateCompletion(requestCtx, request)
-	if err != nil {
-		return nil, fmt.Errorf("openAPI client failed warmup request: %w", err)
-	}
 
 	return client, nil
 }

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 		log.Fatal("Failed to instantiate OpenAPI client", slog.Any("error", err))
 	}
 
-	botInstance := bot.NewAIBot(serviceCtx, openapiClient, discordSession, config.GetStorage(), config.GetImageStorage())
+	botInstance := bot.NewAIBot(serviceCtx, cancel, openapiClient, discordSession, config.GetStorage(), config.GetImageStorage())
 
 	logger.Info("Starting bot")
 	err = botInstance.Go()
@@ -49,9 +49,14 @@ func main() {
 		log.Fatal("Failed to run the bot!", slog.Any("error", err))
 	}
 
-	stop := make(chan os.Signal)
+	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
-	<-stop
+	select {
+	case <-stop:
+		logger.Info("Received shutdown signal")
+	case <-serviceCtx.Done():
+		logger.Info("Service context cancelled (internal shutdown)")
+	}
 
 	logger.Info("Gracefully shutting down")
 	botInstance.Shutdown()

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -85,10 +85,12 @@ resource "aws_ecs_task_definition" "service" {
       image     = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
       essential = true
 
-      environment = []
+      environment = [
+        { name = "AOT_CONFIG_CONTENT", value = file("${path.module}/../adot/otel-agent-config.yaml") },
+      ]
 
       secrets = [
-        { name = "AOT_CONFIG_CONTENT", valueFrom = aws_ssm_parameter.otel_config.arn },
+        { name = "HONEYCOMB_API_KEY", valueFrom = aws_ssm_parameter.honeycomb_api_key.arn },
       ]
 
       mountPoints    = []
@@ -115,6 +117,7 @@ resource "aws_ecs_service" "main" {
   desired_count          = var.desired_count
   enable_execute_command = true
   propagate_tags         = "SERVICE"
+  wait_for_steady_state  = true
 
   capacity_provider_strategy {
     capacity_provider = "FARGATE_SPOT"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -30,7 +30,7 @@ resource "aws_iam_role_policy" "execution_ssm" {
       Resource = [
         aws_ssm_parameter.discord_token.arn,
         aws_ssm_parameter.openai_token.arn,
-        aws_ssm_parameter.otel_config.arn,
+        aws_ssm_parameter.honeycomb_api_key.arn,
       ]
     }]
   })

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -20,9 +20,9 @@ resource "aws_ssm_parameter" "openai_token" {
   }
 }
 
-resource "aws_ssm_parameter" "otel_config" {
-  name        = "/${local.service}/${local.environment}/otel_config"
-  description = "ADOT collector config"
+resource "aws_ssm_parameter" "honeycomb_api_key" {
+  name        = "/${local.service}/${local.environment}/honeycomb_api_key"
+  description = "Honeycomb ingest API key, substituted into adot/otel-agent-config.yaml at runtime"
   type        = "SecureString"
   value       = "populated-out-of-band"
 


### PR DESCRIPTION
## Summary

Four targeted cleanups prompted by the recent incident where exhausted OpenAI credits triggered a crash-loop that eventually got our Discord token revoked.

- **ECS deploys now wait for steady state.** `terraform apply` will surface failed deployments as errors instead of silently returning success the moment the task definition is accepted. (Deployment circuit breaker was already enabled — this completes the picture.)
- **No more OpenAI warmup at startup.** The warmup `CreateCompletion` in `GetOpenAISession` was the root of the incident: out-of-credits → warmup fails → `log.Fatal` → ECS restart → Discord reconnect storm → token revoked. Removed.
- **Detect and handle fatal OpenAI errors.** New `isFatalOpenAIError` recognises `insufficient_quota`, `invalid_api_key`, and HTTP 401. The chat-completion retry loop uses `retry.Unrecoverable` to bail out immediately, and a new `shutdown context.CancelFunc` on `AIBot` triggers a graceful exit so the Discord session closes cleanly (no reconnect storm). The OpenAI error code/status are logged as structured fields for triage.
- **OTEL collector config back in the repo.** `adot/otel-agent-config.yaml` is now the source of truth and is read via Terraform `file()` into `AOT_CONFIG_CONTENT` as a plain env var. The Honeycomb API key is the only sensitive value and lives in a new `aws_ssm_parameter.honeycomb_api_key` SecureString, substituted in by the collector at runtime via `${env:HONEYCOMB_API_KEY}`. The old `aws_ssm_parameter.otel_config` is removed from Terraform.
- **Dockerfile**: replaced misleading empty `ENV` defaults for the Discord/OpenAI tokens with a comment documenting where ECS sources them.

## Operator actions before / after apply

- **Before apply:** create and populate the new SSM parameter `/<service>/<env>/honeycomb_api_key` (SecureString) with the existing Honeycomb key. Otherwise the otel sidecar starts with an empty auth header and Honeycomb exports fail silently.
- **After apply succeeds:** manually delete the now-unused `/<service>/<env>/otel_config` SSM parameter (Terraform no longer manages it).

## Caveat reviewers should know

Fargate restarts a task on any exit, so on persistent OpenAI quota exhaustion the task will still restart — but the Discord session is now closed cleanly each time, which is what stops the reconnect storm and the abuse-detection cascade. To fully halt restarts in that scenario, set `desired_count = 0` (manually or via a CloudWatch alarm). This PR does not add that alarm.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `terraform fmt -check` clean
- [x] `terraform validate` clean
- [x] Populate `honeycomb_api_key` SSM parameter in target account
- [x] `terraform plan` review: confirm `wait_for_steady_state` added, `otel_config` removed, `honeycomb_api_key` added, sidecar `AOT_CONFIG_CONTENT` moved from `secrets` to `environment`, IAM resource list updated
- [x] `terraform apply` reaches steady state; both containers RUNNING
- [ ] Honeycomb dashboard continues receiving traces from the new deploy
- [ ] Mention the bot in Discord; normal completion works end-to-end
- [ ] (Optional) point `BOT_OPENAI_AUTH_TOKEN` SSM at a bad key, redeploy, confirm bot reaches RUNNING (no startup fatal), logs `openai_error_code=invalid_api_key` on first mention, and Discord session closes cleanly before restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)