### PR TITLE
Add image editing via reply or attachment

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -353,15 +353,24 @@ func (b *AIBot) handleImageEditMessage(ctx context.Context, responseChannel, pro
 	if err != nil {
 		return fmt.Errorf("failed to read source image: %w", err)
 	}
-	logger.DebugContext(ctx, "source image fetched", slog.Int("bytes", len(srcBytes)))
+	srcContentType, srcFilename := detectImageType(srcBytes)
+	logger.DebugContext(ctx, "source image fetched",
+		slog.Int("bytes", len(srcBytes)),
+		slog.String("content_type", srcContentType))
+	if srcContentType == "" {
+		return fmt.Errorf("source image is not a supported format (png/jpeg/webp)")
+	}
 
 	fullPrompt := prompt
 	if b.drawingInstructions != "" {
 		fullPrompt = b.drawingInstructions + " " + prompt
 	}
 
+	// The OpenAI multipart encoder needs a recognizable filename + content type;
+	// without it the form part is sent as application/octet-stream and the Edit
+	// endpoint rejects it. openai.File wires both onto the io.Reader.
 	editRequest := openai.ImageEditParams{
-		Image:  openai.ImageEditParamsImageUnion{OfFile: bytes.NewReader(srcBytes)},
+		Image:  openai.ImageEditParamsImageUnion{OfFile: openai.File(bytes.NewReader(srcBytes), srcFilename, srcContentType)},
 		Prompt: fullPrompt,
 		N:      openai.Int(1),
 		User:   openai.String(m.Author.ID),
@@ -418,6 +427,22 @@ func findEditSourceImage(s *discordgo.Session, m *discordgo.MessageCreate) strin
 		}
 	}
 	return ""
+}
+
+// detectImageType sniffs the leading bytes of an image and returns the MIME
+// type + a matching filename for the formats OpenAI's image edit endpoint
+// accepts (png/jpeg/webp). Returns "", "" for anything else.
+func detectImageType(b []byte) (contentType, filename string) {
+	sniffed := http.DetectContentType(b)
+	switch sniffed {
+	case "image/png":
+		return sniffed, "source.png"
+	case "image/jpeg":
+		return sniffed, "source.jpg"
+	case "image/webp":
+		return sniffed, "source.webp"
+	}
+	return "", ""
 }
 
 func isImageAttachment(att *discordgo.MessageAttachment) bool {

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -160,7 +161,28 @@ func (b *AIBot) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) 
 	// Let users know we're "typing", the call to OpenAI can take a few seconds
 	_ = s.ChannelTyping(responseChannel, discordgo.WithContext(ctx))
 
-	if strings.Contains(strings.ToLower(sanitizedUserPrompt), "🎨") || strings.Contains(strings.ToLower(sanitizedUserPrompt), "draw me a picture of") {
+	sourceImageURL := findEditSourceImage(s, m)
+	lowerPrompt := strings.ToLower(sanitizedUserPrompt)
+	wantsEdit := sourceImageURL != "" && (strings.Contains(sanitizedUserPrompt, "✏️") ||
+		strings.Contains(lowerPrompt, "edit:") ||
+		strings.Contains(lowerPrompt, "redraw"))
+	wantsDraw := strings.Contains(lowerPrompt, "🎨") || strings.Contains(lowerPrompt, "draw me a picture of")
+
+	switch {
+	case wantsEdit:
+		editPrompt := stripEditTriggers(sanitizedUserPrompt)
+		err = b.handleImageEditMessage(ctx, responseChannel, editPrompt, sourceImageURL, m)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			_, discordErr := b.discordSession.ChannelMessageSend(responseChannel, fmt.Sprintf("I fucked that up and threw it away. Sorry. (%s)", err.Error()), discordgo.WithContext(ctx))
+			if discordErr != nil {
+				span.RecordError(err)
+				logger.ErrorContext(ctx, "Failed to notify discord channel of the error", slog.Any("error", err))
+			}
+			return
+		}
+	case wantsDraw:
 		// Strip the prompt prefix out of the message
 		sanitizedUserPrompt = strings.ReplaceAll(strings.ToLower(m.Content), "draw me a picture of", "")
 		err = b.handleImageMessage(ctx, responseChannel, sanitizedUserPrompt, m)
@@ -174,7 +196,7 @@ func (b *AIBot) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) 
 			}
 			return
 		}
-	} else {
+	default:
 		err = b.handleCompletionPrompt(ctx, responseChannel, sanitizedUserPrompt, threadPromptContext, m)
 		if err != nil {
 			span.RecordError(err)
@@ -200,7 +222,6 @@ func (b *AIBot) ReadyHandler(_ *discordgo.Session, _ *discordgo.Ready) {
 
 func (b *AIBot) handleImageMessage(ctx context.Context, responseChannel string, prompt string, m *discordgo.MessageCreate) error {
 	var err error
-	logger := slog.Default().WithGroup("handleImageMessage")
 
 	ctx, span := otel.GetTracerProvider().Tracer("AIBot").Start(ctx, "handleImageMessage")
 	defer span.End()
@@ -238,9 +259,21 @@ func (b *AIBot) handleImageMessage(ctx context.Context, responseChannel string, 
 		return fmt.Errorf("failed to get image from openai: %w", err)
 	}
 
-	// gpt-image-1 returns the image as base64 inline; decode it streaming so we
-	// never hold the fully-decoded image in memory alongside the encoded copy.
-	b64 := responseImage.Data[0].B64JSON
+	if err := b.dispatchGeneratedImage(ctx, span, responseChannel, responseImage.Data[0].B64JSON, "a picture I drawed", m); err != nil {
+		return err
+	}
+
+	span.SetStatus(codes.Ok, "Success")
+	return nil
+}
+
+// dispatchGeneratedImage takes a base64 PNG from the OpenAI image API, streams
+// it to Discord as a reply attachment, and concurrently uploads a copy to S3 +
+// records the resulting URL in thread context. Shared between the generation
+// and edit paths.
+func (b *AIBot) dispatchGeneratedImage(ctx context.Context, span trace.Span, responseChannel, b64, content string, m *discordgo.MessageCreate) error {
+	logger := slog.Default().WithGroup("dispatchGeneratedImage")
+
 	imageLength, err := decodedBase64Length(b64)
 	if err != nil {
 		return fmt.Errorf("invalid base64 image from openai: %w", err)
@@ -252,12 +285,11 @@ func (b *AIBot) handleImageMessage(ctx context.Context, responseChannel string, 
 	imageDecoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64))
 	imageTeeReader := io.TeeReader(imageDecoder, pipeWriter)
 
-	// Record the image to S3, and our thread context
 	go func() {
 		defer func() {
 			pipeErr := pipeWriter.Close()
 			if pipeErr != nil {
-				span.RecordError(err)
+				span.RecordError(pipeErr)
 				logger.ErrorContext(ctx, "failed to close the pipeWriter", slog.Any("error", pipeErr))
 			}
 		}()
@@ -271,17 +303,14 @@ func (b *AIBot) handleImageMessage(ctx context.Context, responseChannel string, 
 
 		imageUrl := fmt.Sprintf("https://sillybullshit.click/%s", imageKey)
 
-		// Record the image response to the thread context
-		err = b.storage.AddThreadMessage(ctx, responseChannel, "Bot", imageUrl)
-		if err != nil {
+		if err := b.storage.AddThreadMessage(ctx, responseChannel, "Bot", imageUrl); err != nil {
 			span.RecordError(err)
-			logger.ErrorContext(ctx, "failed to store a copy of the image in S3", slog.Any("error", err))
+			logger.ErrorContext(ctx, "failed to record image URL in thread context", slog.Any("error", err))
 		}
 	}()
 
-	// Embed the image in a discord message, and send it
 	_, err = b.discordSession.ChannelMessageSendComplex(responseChannel, &discordgo.MessageSend{
-		Content:   "a picture I drawed",
+		Content:   content,
 		Reference: m.Reference(),
 		File: &discordgo.File{
 			Name:        "danbot-drawing.png",
@@ -289,13 +318,130 @@ func (b *AIBot) handleImageMessage(ctx context.Context, responseChannel string, 
 			Reader:      pipeReader,
 		},
 	}, discordgo.WithContext(ctx))
-
 	if err != nil {
 		return fmt.Errorf("failed to send embedded image to discord: %w", err)
+	}
+	return nil
+}
+
+// handleImageEditMessage takes a prompt and a URL to an existing image and asks
+// OpenAI's image edit endpoint to produce a modified version, then ships it the
+// same way handleImageMessage does for fresh generations.
+func (b *AIBot) handleImageEditMessage(ctx context.Context, responseChannel, prompt, sourceURL string, m *discordgo.MessageCreate) error {
+	logger := slog.Default().WithGroup("handleImageEditMessage")
+
+	ctx, span := otel.GetTracerProvider().Tracer("AIBot").Start(ctx, "handleImageEditMessage")
+	defer span.End()
+	span.SetAttributes(attribute.String("source_url", sourceURL))
+
+	if err := b.storage.AddThreadMessage(ctx, responseChannel,
+		fmt.Sprintf("%s (%s) on %s", m.Author.Username, m.Author.ID, m.GuildID),
+		fmt.Sprintf("edit: %s (source: %s)", prompt, sourceURL)); err != nil {
+		return fmt.Errorf("failed to record edit prompt: %w", err)
+	}
+
+	src, _, err := b.imageStorage.GetImageFromURL(ctx, sourceURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch source image: %w", err)
+	}
+	defer src.Close()
+
+	// The Edit endpoint sends the image as multipart form data, which means the
+	// SDK reads the whole body up front — buffer it here so we can pass an
+	// io.Reader that won't get drained partway through.
+	srcBytes, err := io.ReadAll(src)
+	if err != nil {
+		return fmt.Errorf("failed to read source image: %w", err)
+	}
+	logger.DebugContext(ctx, "source image fetched", slog.Int("bytes", len(srcBytes)))
+
+	fullPrompt := prompt
+	if b.drawingInstructions != "" {
+		fullPrompt = b.drawingInstructions + " " + prompt
+	}
+
+	editRequest := openai.ImageEditParams{
+		Image:  openai.ImageEditParamsImageUnion{OfFile: bytes.NewReader(srcBytes)},
+		Prompt: fullPrompt,
+		N:      openai.Int(1),
+		User:   openai.String(m.Author.ID),
+		Size:   openai.ImageEditParamsSize1024x1024,
+		Model:  openai.ImageModelGPTImage1,
+	}
+	span.SetAttributes(
+		attribute.String("model", string(editRequest.Model)),
+		attribute.String("size", string(editRequest.Size)),
+	)
+
+	responseImage, err := b.openapiClient.Images.Edit(ctx, editRequest)
+	if err != nil {
+		if isFatalOpenAIError(err) {
+			b.handleFatalOpenAIError(ctx, err)
+		}
+		return fmt.Errorf("failed to edit image via openai: %w", err)
+	}
+
+	if err := b.dispatchGeneratedImage(ctx, span, responseChannel, responseImage.Data[0].B64JSON, "here ya go", m); err != nil {
+		return err
 	}
 
 	span.SetStatus(codes.Ok, "Success")
 	return nil
+}
+
+// findEditSourceImage returns a URL to an image to be used as the source for an
+// edit, preferring an attachment on the triggering message, then falling back
+// to an attachment on the message it's replying to (if that message came from
+// us). Returns "" when no candidate exists.
+func findEditSourceImage(s *discordgo.Session, m *discordgo.MessageCreate) string {
+	for _, att := range m.Attachments {
+		if isImageAttachment(att) {
+			return att.URL
+		}
+	}
+
+	ref := m.ReferencedMessage
+	if ref == nil && m.MessageReference != nil && m.MessageReference.MessageID != "" {
+		// The gateway doesn't always inline ReferencedMessage — older messages
+		// or cache misses fall back to an explicit fetch.
+		fetched, err := s.ChannelMessage(m.MessageReference.ChannelID, m.MessageReference.MessageID)
+		if err == nil {
+			ref = fetched
+		}
+	}
+	if ref == nil || ref.Author == nil || ref.Author.ID != s.State.User.ID {
+		return ""
+	}
+	for _, att := range ref.Attachments {
+		if isImageAttachment(att) {
+			return att.URL
+		}
+	}
+	return ""
+}
+
+func isImageAttachment(att *discordgo.MessageAttachment) bool {
+	if att == nil {
+		return false
+	}
+	if strings.HasPrefix(att.ContentType, "image/") {
+		return true
+	}
+	lower := strings.ToLower(att.Filename)
+	return strings.HasSuffix(lower, ".png") ||
+		strings.HasSuffix(lower, ".jpg") ||
+		strings.HasSuffix(lower, ".jpeg") ||
+		strings.HasSuffix(lower, ".webp")
+}
+
+func stripEditTriggers(prompt string) string {
+	out := strings.ReplaceAll(prompt, "✏️", "")
+	out = strings.ReplaceAll(out, "edit:", "")
+	out = strings.ReplaceAll(out, "Edit:", "")
+	out = strings.ReplaceAll(out, "EDIT:", "")
+	out = strings.ReplaceAll(out, "redraw", "")
+	out = strings.ReplaceAll(out, "Redraw", "")
+	return strings.TrimSpace(out)
 }
 
 // Handle a text completion prompt, including applying existing thread context and updating the stored state of that context


### PR DESCRIPTION
## Summary
- Lets users iterate on a previously-drawn Danbot image by replying to it with a prompt containing `✏️`, `edit:`, or `redraw` — the bot fetches the source from the reply's attachment, sends it to OpenAI's `Images.Edit` along with `drawingInstructions`, and posts the result the same way fresh generations are posted.
- Users can also attach their own image to the trigger message (attachment takes precedence over the replied-to image).
- Extracts the shared "base64 → tee → S3 + Discord reply" tail into `dispatchGeneratedImage` so the generate and edit paths share it.

## Why
Most iteration we expect to do on Danbot drawings is small ("add a hat", "make it blue") — currently the only option is regenerating from scratch, which loses the original composition. The OpenAI Images.Edit endpoint is already available via the SDK we use; this wires it up.

## Notes for reviewers
- **Trigger rules:** edit only fires when there's a usable source image *and* the prompt contains `✏️`, `edit:`, or `redraw`. Plain replies still go through the chat path so casual reply-style conversation isn't hijacked.
- **Source precedence:** the triggering message's own attachment first, then the replied-to message's attachment — but only if that message came from the bot (avoids editing arbitrary user-uploaded images via reply).
- **ReferencedMessage fallback:** the gateway doesn't always inline `m.ReferencedMessage` (cache misses on older messages), so we fall back to `s.ChannelMessage(...)`.
- **Buffering:** the Edit endpoint marshals multipart up front, so the source image is read fully into memory before the API call. Single 1024x1024 PNG, ~1MB — fine.
- `handleImageMessage` is ~25 lines lighter now that the dispatch tail is shared.

## Test plan
- [ ] Reply to a Danbot drawing with `✏️ add a hat` and confirm an edited image comes back in the channel/thread.
- [ ] Attach an arbitrary image with `edit: make it sepia` and confirm it edits the attached image, ignoring any reply context.
- [ ] Plain `🎨` and `draw me a picture of` flows still work.
- [ ] Plain reply to a bot image without an edit trigger word still goes to the chat path.
- [ ] Reply to a very old Danbot image (cache miss path) still resolves the source attachment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)